### PR TITLE
Add Typedoc auto-gen

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -40,23 +40,36 @@ jobs:
         run: yarn install --frozen-lockfile
         working-directory: packages/website
 
-      - name: build website
-        run: yarn build
-        working-directory: packages/website
+      # Uncomment to deploy Docusaurus website.
+      # - name: build website
+      #   run: yarn build
+      #   working-directory: packages/website
 
-      - name: upload artifact
-        uses: actions/upload-pages-artifact@v1
+      # - name: upload artifact
+      #   uses: actions/upload-pages-artifact@v1
+      #   with:
+      #     path: packages/website/build
+
+      - name: generate doc website
+        run: yarn docs
+
+      - name: publish
+        uses: crazy-max/ghaction-github-pages@v2.5.0
         with:
-          path: packages/website/build
+            build_dir: docs
+            jekyll: false
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Uncomment to deploy Docusaurus website.
   # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+  # deploy:
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ coverage/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# docs
+docs/*
+!docs/CNAME
+!docs/index.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+
+<html style="height: 100%">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="IE=edge" />
+        <title>p0tion packages</title>
+        <meta
+            name="description"
+            content="A monorepo of p0tion packages."
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+        />
+    </head>
+    <body
+        style="
+            margin: 0;
+            background-color: #EAF0F4;
+            color: #000;
+            height: 100%;
+            font-family: 'Courier New', monospace;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+        "
+    >
+        <div
+            style="
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                flex: 1;
+                padding: 0 20px;
+                text-align: center;
+            "
+        >
+            <div style="display: flex">
+                <h1 style="margin: 0; font-size: 40px">🧪 p0tion packages</h1>
+            </div>
+            <p style="max-width: 500px">
+                A monorepo of p0tion packages.
+            </p>
+            <ul style="list-style-type: none; padding: 0; margin: 0; margin-top: 10px"></ul>
+        </div>
+        <footer
+            style="
+                display: flex;
+                justify-content: center;
+                padding: 15px 20px;
+                background-color: #EAF0F4;
+            "
+        >
+            <div
+                style="
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    width: 900px;
+                "
+            >
+                <p style="margin: 0; font-size: 16px">
+                    Copyright © 2023 Ethereum Foundation
+                </p>
+                <div>
+                    <a
+                        style="margin-right: 15px; text-decoration: none"
+                        target="_blank"
+                        href="https://github.com/privacy-scaling-explorations/p0tion"
+                    >
+                        <i
+                            class="fa fa-github"
+                            style="font-size: 24px; color: #000"
+                        ></i>
+                    </a>
+                </div>
+            </div>
+        </footer>
+    </body>
+    <script>
+        const url =
+            "https://api.github.com/repos/privacy-scaling-explorations/p0tion/contents?ref=gh-pages"
+
+        function insertLinks(packages) {
+            const [element] = window.document.getElementsByTagName("ul")
+            let html = ""
+
+            for (const package of packages) {
+                html += `<li style="display: flex; align-items: center; margin-bottom: 8px">
+            <a style="margin-right: 15px" target="_blank" href="https://github.com/privacy-scaling-explorations/p0tion/tree/main/packages/${package}">
+              <i class="fa fa-github" style="font-size: 24px; color: #000"></i>
+            </a>
+            <a style="color: #000; text-decoration: none; font-size: 16px"
+              onmouseover="this.style.color='#404A4E';"
+              onmouseout="this.style.color='#000';"
+              target="_blank" href="https://privacy-scaling-explorations.github.io/p0tion/${package}">
+                @privacy-scaling-explorations/${package} >
+            </a></li>`
+            }
+
+            element.innerHTML = html
+        }
+
+        fetch(url)
+            .then((response) => response.json())
+            .then((data) => {
+                const ignore = [".nojekyll", "index.html", "CNAME"]
+                const packages = data
+                    .map((c) => c.name)
+                    .filter((name) => !ignore.includes(name))
+
+                localStorage.setItem("packages", JSON.stringify(packages))
+
+                insertLinks(packages)
+            })
+    </script>
+</html>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "prettier:fix": "prettier -w .",
         "precommit": "lint-staged",
         "commit": "cz",
-        "prepare": "is-ci || husky install"
+        "prepare": "is-ci || husky install",
+        "docs": "yarn workspaces foreach --no-private run docs"
     },
     "devDependencies": {
         "@babel/core": "^7.20.2",
@@ -63,7 +64,8 @@
         "lint-staged": "^13.1.0",
         "prettier": "^2.8.3",
         "rimraf": "^3.0.2",
-        "rollup": "^3.4.0"
+        "rollup": "^3.4.0",
+        "typedoc": "^0.24.4"
     },
     "config": {
         "commitizen": {

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -36,7 +36,8 @@
         "pre:publish": "yarn build",
         "compile:contracts": "hardhat compile",
         "test:contracts": "GOOGLE_APPLICATION_CREDENTIALS=\"../backend/serviceAccountKey.json\" && NODE_ENV=prod hardhat test test/unit/contract.test.ts",
-        "verify:ceremony": "GOOGLE_APPLICATION_CREDENTIALS=\"../backend/serviceAccountKey.json\" && NODE_ENV=prod hardhat verifyCeremony"
+        "verify:ceremony": "GOOGLE_APPLICATION_CREDENTIALS=\"../backend/serviceAccountKey.json\" && NODE_ENV=prod hardhat verifyCeremony",
+        "docs": "typedoc src/**/*.ts --out ../../docs/actions"
     },
     "dependencies": {
         "@octokit/auth-oauth-device": "^4.0.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,8 @@
         "emulator:serve-functions": "yarn build && firebase emulators:start --only functions",
         "emulator:shell": "yarn build && firebase functions:shell",
         "emulator:exec-test": "firebase --project dev emulators:exec \"yarn test:emulator\"",
-        "test:emulator": "jest --config=../../jest.json --detectOpenHandles --forceExit --coverage=false --watchAll=false --no-cache"
+        "test:emulator": "jest --config=../../jest.json --detectOpenHandles --forceExit --coverage=false --watchAll=false --no-cache",
+        "docs": "typedoc src/**/*.ts --out ../../docs/backend"
     },
     "peerDependencies": {
         "@p0tion/actions": "^0.1.0"

--- a/packages/phase2cli/package.json
+++ b/packages/phase2cli/package.json
@@ -41,7 +41,8 @@
         "logout": "yarn start logout",
         "coordinate:setup": "yarn start coordinate setup",
         "coordinate:observe": "yarn start coordinate observe",
-        "coordinate:finalize": "yarn start coordinate finalize"
+        "coordinate:finalize": "yarn start coordinate finalize",
+        "docs": "typedoc src/**/*.ts --out ../../docs/phase2cli"
     },
     "peerDependencies": {
         "@p0tion/actions": "^0.1.0"

--- a/packages/phase2cli/src/commands/auth.ts
+++ b/packages/phase2cli/src/commands/auth.ts
@@ -21,7 +21,7 @@ dotenv.config()
  * Custom countdown which throws an error when expires.
  * @param expirationInSeconds <number> - the expiration time in seconds.
  */
-const expirationCountdownForGithubOAuth = (expirationInSeconds: number) => {
+export const expirationCountdownForGithubOAuth = (expirationInSeconds: number) => {
     // Prepare data.
     let secondsCounter = expirationInSeconds <= 60 ? expirationInSeconds : 60
     const interval = 1 // 1s.

--- a/packages/phase2cli/src/commands/contribute.ts
+++ b/packages/phase2cli/src/commands/contribute.ts
@@ -47,7 +47,7 @@ import { checkAndMakeNewDirectoryIfNonexistent, writeFile } from "../lib/files"
  * @param ceremonyTitle <string> - the title of the ceremony.
  * @param gistUrl <string> - the Github public attestation gist url.
  */
-const handleTweetGeneration = async (ceremonyTitle: string, gistUrl: string): Promise<void> => {
+export const handleTweetGeneration = async (ceremonyTitle: string, gistUrl: string): Promise<void> => {
     // Generate a ready to share custom url to tweet about ceremony participation.
     const tweetUrl = generateCustomUrlToTweetAboutParticipation(ceremonyTitle, gistUrl, false)
 
@@ -67,7 +67,7 @@ const handleTweetGeneration = async (ceremonyTitle: string, gistUrl: string): Pr
  * Display if a set of contributions computed for a circuit is valid/invalid.
  * @param contributionsWithValidity <Array<ContributionValidity>> - list of contributor contributions together with contribution validity.
  */
-const displayContributionValidity = (contributionsWithValidity: Array<ContributionValidity>) => {
+export const displayContributionValidity = (contributionsWithValidity: Array<ContributionValidity>) => {
     // Circuit index position.
     let circuitSequencePosition = 1 // nb. incremental value is enough because the contributions are already sorted x circuit sequence position.
 
@@ -91,7 +91,7 @@ const displayContributionValidity = (contributionsWithValidity: Array<Contributi
  * @param ceremonyId <string> - the unique identifier of the ceremony.
  * @param participantId <string> - the unique identifier of the contributor.
  */
-const handleContributionValidity = async (
+export const handleContributionValidity = async (
     firestoreDatabase: Firestore,
     circuits: Array<FirebaseDocumentInfo>,
     ceremonyId: string,
@@ -141,7 +141,7 @@ const handleContributionValidity = async (
  * @param participantContributionProgress <number> - the progress in the contribution of the various circuits of the ceremony.
  * @param wasContributing <boolean> - flag to discriminate between participant currently contributing (true) or not (false).
  */
-const handleTimedoutMessageForContributor = async (
+export const handleTimedoutMessageForContributor = async (
     firestoreDatabase: Firestore,
     participantId: string,
     ceremonyId: string,
@@ -203,7 +203,7 @@ const handleTimedoutMessageForContributor = async (
  * @param isResumingAfterTimeout <boolean> - flag to discriminate between resuming after a timeout expiration (true) or progressing to next contribution (false).
  * @return <Promise<boolean>> - true when the contributor would like to generate the attestation and do not provide any further contribution to the ceremony; otherwise false.
  */
-const handleDiskSpaceRequirementForNextContribution = async (
+export const handleDiskSpaceRequirementForNextContribution = async (
     cloudFunctions: Functions,
     ceremonyId: string,
     circuitSequencePosition: number,
@@ -282,7 +282,7 @@ const handleDiskSpaceRequirementForNextContribution = async (
  * @param ceremonyName <string> - the name of the ceremony.
  * @returns <Promise<string>> - the public attestation.
  */
-const generatePublicAttestation = async (
+export const generatePublicAttestation = async (
     firestoreDatabase: Firestore,
     circuits: Array<FirebaseDocumentInfo>,
     ceremonyId: string,
@@ -319,7 +319,7 @@ const generatePublicAttestation = async (
  * @param ceremonyPrefix <string> - the prefix of the ceremony.
  * @param participantAccessToken <string> - the access token of the participant.
  */
-const handlePublicAttestation = async (
+export const handlePublicAttestation = async (
     firestoreDatabase: Firestore,
     circuits: Array<FirebaseDocumentInfo>,
     ceremonyId: string,
@@ -374,7 +374,7 @@ const handlePublicAttestation = async (
  * @param circuitCurrentContributor <DocumentSnapshot<DocumentData>> - the Firestore document of the current circuit contributor.
  * @param completedContributions <number> - the amount of completed and valid circuit contributions so far.
  */
-const listenToCircuitCurrentContributorDocumentChanges = async (
+export const listenToCircuitCurrentContributorDocumentChanges = async (
     firestoreDatabase: Firestore,
     ceremonyId: string,
     circuitId: string,
@@ -524,7 +524,7 @@ const listenToCircuitCurrentContributorDocumentChanges = async (
  * @param participantId <string> - the unique identifier of the participant.
  * @param circuit <FirebaseDocumentInfo> - the Firestore document info about the circuit.
  */
-const listenToCeremonyCircuitDocumentChanges = (
+export const listenToCeremonyCircuitDocumentChanges = (
     firestoreDatabase: Firestore,
     ceremonyId: string,
     participantId: string,
@@ -643,7 +643,7 @@ const listenToCeremonyCircuitDocumentChanges = (
  * @param providerUserId <string> - the unique provider user identifier associated to the authenticated account.
  * @param accessToken <string> - the Github token generated through the Device Flow process.
  */
-const listenToParticipantDocumentChanges = async (
+export const listenToParticipantDocumentChanges = async (
     firestoreDatabase: Firestore,
     cloudFunctions: Functions,
     participant: DocumentSnapshot<DocumentData>,

--- a/packages/phase2cli/src/commands/finalize.ts
+++ b/packages/phase2cli/src/commands/finalize.ts
@@ -54,7 +54,7 @@ import { promptForCeremonySelection, promptToTypeEntropyOrBeacon } from "../lib/
  * @param verificationKeyLocalFilePath <string> - the local file path of the verification key.
  * @param verificationKeyStorageFilePath <string> - the storage file path of the verification key.
  */
-const handleVerificationKey = async (
+export const handleVerificationKey = async (
     cloudFunctions: Functions,
     bucketName: string,
     finalZkeyLocalFilePath: string,
@@ -94,7 +94,7 @@ const handleVerificationKey = async (
  * @param verifierContractLocalFilePath <string> - the local file path of the verifier smart contract.
  * @param verifierContractStorageFilePath <string> - the storage file path of the verifier smart contract.
  */
-const handleVerifierSmartContract = async (
+export const handleVerifierSmartContract = async (
     cloudFunctions: Functions,
     bucketName: string,
     finalZkeyLocalFilePath: string,
@@ -146,7 +146,7 @@ const handleVerifierSmartContract = async (
  * @param beacon <string> - the value used to compute the final contribution while finalizing the ceremony.
  * @param coordinatorIdentifier <string> - the identifier of the coordinator.
  */
-const handleCircuitFinalization = async (
+export const handleCircuitFinalization = async (
     cloudFunctions: Functions,
     firestoreDatabase: Firestore,
     ceremony: FirebaseDocumentInfo,

--- a/packages/phase2cli/src/commands/observe.ts
+++ b/packages/phase2cli/src/commands/observe.ts
@@ -21,7 +21,7 @@ import theme from "../lib/theme"
  * @param currentCursorPos - the current position of the cursor.
  * @returns <number>
  */
-const cleanCursorPosBackToRoot = (currentCursorPos: number) => {
+export const cleanCursorPosBackToRoot = (currentCursorPos: number) => {
     while (currentCursorPos < 0) {
         // Get back and clean line by line.
         readline.cursorTo(process.stdout, 0)
@@ -41,7 +41,7 @@ const cleanCursorPosBackToRoot = (currentCursorPos: number) => {
  * @param circuit <FirebaseDocumentInfo> - the Firebase document containing info about the circuit.
  * @returns Promise<number> return the current position of the cursor (i.e., number of lines displayed).
  */
-const displayLatestCircuitUpdates = async (
+export const displayLatestCircuitUpdates = async (
     firestoreDatabase: Firestore,
     ceremony: FirebaseDocumentInfo,
     circuit: FirebaseDocumentInfo

--- a/packages/phase2cli/src/commands/setup.ts
+++ b/packages/phase2cli/src/commands/setup.ts
@@ -72,7 +72,7 @@ import {
  * @param sharedCircomCompilerData <string> - version and commit hash of the Circom compiler used to compile the ceremony circuits.
  * @returns <Promise<CircuitInputData>> - the input data of the circuit to add to the ceremony.
  */
-const getInputDataToAddCircuitToCeremony = async (
+export const getInputDataToAddCircuitToCeremony = async (
     choosenCircuitFilename: string,
     matchingWasmFilename: string,
     ceremonyTimeoutMechanismType: CeremonyTimeoutType,
@@ -131,7 +131,7 @@ const getInputDataToAddCircuitToCeremony = async (
  * @param ceremonyTimeoutMechanismType <CeremonyTimeoutType> - the type of ceremony timeout mechanism.
  * @returns <Promise<Array<CircuitInputData>>> - the input data for each circuit that has been added to the ceremony.
  */
-const handleAdditionOfCircuitsToCeremony = async (
+export const handleAdditionOfCircuitsToCeremony = async (
     r1csOptions: Array<string>,
     wasmOptions: Array<string>,
     ceremonyTimeoutMechanismType: CeremonyTimeoutType
@@ -208,7 +208,7 @@ const handleAdditionOfCircuitsToCeremony = async (
  * @param ceremonyInputData <CeremonyInputData> - the input data of the ceremony.
  * @param circuits <Array<CircuitDocument>> - the circuit documents associated to the circuits of the ceremony.
  */
-const displayCeremonySummary = (ceremonyInputData: CeremonyInputData, circuits: Array<CircuitDocument>) => {
+export const displayCeremonySummary = (ceremonyInputData: CeremonyInputData, circuits: Array<CircuitDocument>) => {
     // Prepare ceremony summary.
     let summary = `${`${theme.text.bold(ceremonyInputData.title)}\n${theme.text.italic(ceremonyInputData.description)}`}
         \n${`Opening: ${theme.text.bold(
@@ -263,7 +263,7 @@ const displayCeremonySummary = (ceremonyInputData: CeremonyInputData, circuits: 
  * @param ptauCompleteFilename <string> - the complete file name of the powers of tau file to be downloaded.
  * @returns <Promise<void>>
  */
-const checkAndDownloadSmallestPowersOfTau = async (powers: string, ptauCompleteFilename: string): Promise<void> => {
+export const checkAndDownloadSmallestPowersOfTau = async (powers: string, ptauCompleteFilename: string): Promise<void> => {
     // Get already downloaded ptau files.
     const alreadyDownloadedPtauFiles = await getDirFilesSubPaths(localPaths.pot)
 
@@ -309,7 +309,7 @@ const checkAndDownloadSmallestPowersOfTau = async (powers: string, ptauCompleteF
  * @returns Promise<string, string> - the information about the choosen Powers of Tau file for the pre-computed zKey
  * along with related powers.
  */
-const handlePreComputedZkeyPowersOfTauSelection = async (
+export const handlePreComputedZkeyPowersOfTauSelection = async (
     neededPowers: number
 ): Promise<{
     doubleDigitsPowers: string
@@ -366,7 +366,7 @@ const handlePreComputedZkeyPowersOfTauSelection = async (
  * @param potLocalPathAndFileName <string> - the local complete path of the PoT selected file.
  * @param zkeyLocalPathAndFileName <string> - the local complete path of the pre-computed zKey selected file.
  */
-const handleNewZkeyGeneration = async (
+export const handleNewZkeyGeneration = async (
     r1csLocalPathAndFileName: string,
     potLocalPathAndFileName: string,
     zkeyLocalPathAndFileName: string
@@ -389,7 +389,7 @@ const handleNewZkeyGeneration = async (
  * @param ceremonyPrefix <string> - the prefix of the ceremony.
  * @returns <Promise<string>> - the ceremony bucket name.
  */
-const handleCeremonyBucketCreation = async (firebaseFunctions: Functions, ceremonyPrefix: string): Promise<string> => {
+export const handleCeremonyBucketCreation = async (firebaseFunctions: Functions, ceremonyPrefix: string): Promise<string> => {
     // Compose bucket name using the ceremony prefix.
     const bucketName = getBucketName(ceremonyPrefix, process.env.CONFIG_CEREMONY_BUCKET_POSTFIX!)
 
@@ -418,7 +418,7 @@ const handleCeremonyBucketCreation = async (firebaseFunctions: Functions, ceremo
  * @param localPathAndFileName <string> - the local file path where is located.
  * @param completeFilename <string> - the complete filename.
  */
-const handleCircuitArtifactUploadToStorage = async (
+export const handleCircuitArtifactUploadToStorage = async (
     firebaseFunctions: Functions,
     bucketName: string,
     storageFilePath: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,6 +8200,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-sequence-parser@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "ansi-sequence-parser@npm:1.1.0"
+  checksum: 75f4d3a4c555655a698aec05b5763cbddcd16ccccdbfd178fb0aa471ab74fdf98e031b875ef26e64be6a95cf970c89238744b26de6e34af97f316d5186b1df53
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -16220,6 +16227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "jsonc-parser@npm:3.2.0"
+  checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
+  languageName: node
+  linkType: hard
+
 "jsonfile@npm:^2.1.0":
   version: 2.4.0
   resolution: "jsonfile@npm:2.4.0"
@@ -17032,6 +17046,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 176719e24fcce7d3cf1baccce9dd5633cd8bdc1f41ebe6a180112e5ee99d80373fe2454f5d4624d437e5a8319698ca6837b9950566e15d2cae5f2a543a3db4b8
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.25.7":
   version: 0.25.9
   resolution: "magic-string@npm:0.25.9"
@@ -17152,7 +17173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.0.10, marked@npm:^4.0.14":
+"marked@npm:^4.0.10, marked@npm:^4.0.14, marked@npm:^4.3.0":
   version: 4.3.0
   resolution: "marked@npm:4.3.0"
   bin:
@@ -17504,6 +17525,15 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 9e341b04e69d5ab03e4206dcb61c8a158e3b8709628bf5e1a4eaa9f3b72c0ba925e24ad959b1f6ce6835caa5a927131d5087fae6836b69e7d99d7d5e63ef0bd8
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "minimatch@npm:9.0.0"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 7bd57899edd1d1b0560f50b5b2d1ea4ad2a366c5a2c8e0a943372cf2f200b64c256bae45a87a80915adbce27fa36526264296ace0da57b600481fe5ea3e372e5
   languageName: node
   linkType: hard
 
@@ -18491,6 +18521,7 @@ __metadata:
     prettier: ^2.8.3
     rimraf: ^3.0.2
     rollup: ^3.4.0
+    typedoc: ^0.24.4
   languageName: unknown
   linkType: soft
 
@@ -21275,6 +21306,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shiki@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "shiki@npm:0.14.1"
+  dependencies:
+    ansi-sequence-parser: ^1.1.0
+    jsonc-parser: ^3.2.0
+    vscode-oniguruma: ^1.7.0
+    vscode-textmate: ^8.0.0
+  checksum: b19ea337cc84da69d99ca39d109f82946e0c56c11cc4c67b3b91cc14a9479203365fd0c9e0dd87e908f493ab409dc6f1849175384b6ca593ce7da884ae1edca2
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -22676,6 +22719,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedoc@npm:^0.24.4":
+  version: 0.24.4
+  resolution: "typedoc@npm:0.24.4"
+  dependencies:
+    lunr: ^2.3.9
+    marked: ^4.3.0
+    minimatch: ^9.0.0
+    shiki: ^0.14.1
+  peerDependencies:
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+  bin:
+    typedoc: bin/typedoc
+  checksum: c6762aff2b40eb574fc348c82921471fa1c1dc8a83adc284457aab30ea61768770be469f424340ab646944472653290578fd8e6308d55ec2e611577472067dae
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^4.6.4 || ^5.0.0":
   version: 5.0.2
   resolution: "typescript@npm:5.0.2"
@@ -23302,6 +23361,20 @@ __metadata:
   bin:
     vm2: bin/vm2
   checksum: 1ed7481e07ce8e03055101b382bfbf0d725a5c9b9bbe8bf75f71501cb43a6bd22f6a0a151975ff7cea8cad136d47e66d64f0a3248913f6d3ca3c405db12bacc0
+  languageName: node
+  linkType: hard
+
+"vscode-oniguruma@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "vscode-oniguruma@npm:1.7.0"
+  checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
+  languageName: node
+  linkType: hard
+
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0"
+  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds self-generation of individual package documentation with `typedoc`. In order to take advantage of it, a static page referring to packages has been designed. It turns out that it is necessary to deploy `docs` with `gh-pages` so the related Github action has been modified since the `website` package is currently unused.