### PR TITLE
chore: add missing dependency declaration

### DIFF
--- a/packages/phase2cli/package.json
+++ b/packages/phase2cli/package.json
@@ -64,6 +64,7 @@
     },
     "dependencies": {
         "@adobe/node-fetch-retry": "^2.2.0",
+        "@aws-sdk/client-s3": "^3.329.0",
         "@octokit/auth-oauth-app": "^5.0.5",
         "@octokit/auth-oauth-device": "^4.0.4",
         "@octokit/request": "^6.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6225,6 +6225,7 @@ __metadata:
   resolution: "@p0tion/phase2cli@workspace:packages/phase2cli"
   dependencies:
     "@adobe/node-fetch-retry": ^2.2.0
+    "@aws-sdk/client-s3": ^3.329.0
     "@octokit/auth-oauth-app": ^5.0.5
     "@octokit/auth-oauth-device": ^4.0.4
     "@octokit/request": ^6.2.3


### PR DESCRIPTION
Fix that phase2cli has used @aws-sdk/client-s3 in https://github.com/privacy-scaling-explorations/p0tion/blob/0e213d97f3e0381bc1caed4a4b91019dcbe7d079/packages/phase2cli/src/commands/setup.ts#L10 but it was not explicitly declared in package.json.

