### PR TITLE
feat(contribute): cli flag for auth token (run on VM)

### DIFF
--- a/packages/phase2cli/src/commands/contribute.ts
+++ b/packages/phase2cli/src/commands/contribute.ts
@@ -40,7 +40,7 @@ import {
     estimateParticipantFreeGlobalDiskSpace
 } from "../lib/utils.js"
 import { COMMAND_ERRORS, showError } from "../lib/errors.js"
-import { bootstrapCommandExecutionAndServices, checkAuth } from "../lib/services.js"
+import { authWithToken, bootstrapCommandExecutionAndServices, checkAuth } from "../lib/services.js"
 import { getAttestationLocalFilePath, localPaths } from "../lib/localConfigs.js"
 import theme from "../lib/theme.js"
 import { checkAndMakeNewDirectoryIfNonexistent, writeFile } from "../lib/files.js"
@@ -891,12 +891,13 @@ export const listenToParticipantDocumentChanges = async (
 const contribute = async (opt: any) => {
     const { firebaseApp, firebaseFunctions, firestoreDatabase } = await bootstrapCommandExecutionAndServices()
 
-    // Check for authentication.
-    const { user, providerUserId, token } = await checkAuth(firebaseApp)
-
     // Get options.
     const ceremonyOpt = opt.ceremony
     const entropyOpt = opt.entropy
+    const auth = opt.auth 
+
+    // Check for authentication.
+    const { user, providerUserId, token } = auth ? await authWithToken(firebaseApp, auth) : await checkAuth(firebaseApp)
 
     // Prepare data.
     let selectedCeremony: FirebaseDocumentInfo

--- a/packages/phase2cli/src/index.ts
+++ b/packages/phase2cli/src/index.ts
@@ -21,6 +21,7 @@ program
     .description("compute contributions for a Phase2 Trusted Setup ceremony circuits")
     .option("-c, --ceremony <string>", "the prefix of the ceremony you want to contribute for", "")
     .option("-e, --entropy <string>", "the entropy (aka toxic waste) of your contribution", "")
+    .option("-a, --auth <string>", "the Github OAuth 2.0 token", "")
     .action(contribute)
 program
     .command("clean")


### PR DESCRIPTION
In order to contribute to large circuits, one might use a VM. With this feat they can auth on their local machine, take the token and use it in a VM without graphical interface using --auth $TOKEN