### PR TITLE
fix `cfOrVm` prompt

### DIFF
--- a/packages/phase2cli/src/lib/prompts.ts
+++ b/packages/phase2cli/src/lib/prompts.ts
@@ -343,7 +343,7 @@ export const promptCircuitInputData = async (
     let circomVersion: string = ""
     let circomCommitHash: string = ""
     let circuitInputData: CircuitInputData
-    let useCfOrVm: CircuitContributionVerificationMechanism
+    let cfOrVm: CircuitContributionVerificationMechanism
     let vmDiskType: DiskTypeForVM
     let vmConfigurationType: string = ""
 
@@ -429,12 +429,17 @@ export const promptCircuitInputData = async (
             `CF`, // eq. true.
             `VM` // eq. false.
         )
-        useCfOrVm = confirmation
-    } else useCfOrVm = CircuitContributionVerificationMechanism.VM
+        cfOrVm = confirmation
+            ? CircuitContributionVerificationMechanism.CF
+            : CircuitContributionVerificationMechanism.VM
 
-    if (useCfOrVm === undefined) showError(COMMAND_ERRORS.COMMAND_ABORT_PROMPT, true)
+    } else {
+        cfOrVm = CircuitContributionVerificationMechanism.VM
+    }
 
-    if (!useCfOrVm) {
+    if (cfOrVm === undefined) showError(COMMAND_ERRORS.COMMAND_ABORT_PROMPT, true)
+
+    if (cfOrVm === CircuitContributionVerificationMechanism.VM) {
         // Ask for selecting the specific VM configuration type.
         vmConfigurationType = await promptVMTypeSelector(constraintSize)
 
@@ -478,9 +483,7 @@ export const promptCircuitInputData = async (
                 paramsConfiguration: circuitConfigurationValues
             },
             verification: {
-                cfOrVm: useCfOrVm
-                    ? CircuitContributionVerificationMechanism.CF
-                    : CircuitContributionVerificationMechanism.VM,
+                cfOrVm,
                 vm: {
                     vmConfigurationType,
                     vmDiskType
@@ -520,9 +523,7 @@ export const promptCircuitInputData = async (
                 paramsConfiguration: circuitConfigurationValues
             },
             verification: {
-                cfOrVm: useCfOrVm
-                    ? CircuitContributionVerificationMechanism.CF
-                    : CircuitContributionVerificationMechanism.VM,
+                cfOrVm,
                 vm: {
                     vmConfigurationType,
                     vmDiskType


### PR DESCRIPTION

# Description

Expected behavior:
When setting up a ceremony for a circuit with >1M constraints, the CLI automatically chooses VM verification and promps the user to select and instance type.

Actual behavior:
When setting up a ceremony for a circuit with >1M constraints, the CLI automatically chooses CF verification

The reason this occurs was because we assume `cfOrVM` is a `boolean` when it's actually a string in the case that `enforceVm` is `true`. Since the string is truthy, the CLI sets it to CF verification instead of VM verification.


# Checklist:

-   [X] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [X] Any dependent changes have been merged and published in downstream modules
-   [X] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
