### PR TITLE
add instance profile ARN to `.env.default` and use it when creating EC2 instance

### DIFF
--- a/packages/actions/.env.default
+++ b/packages/actions/.env.default
@@ -48,6 +48,8 @@ AWS_REGION="YOUR-AWS-REGION"
 AWS_AMI_ID="ami-022e1a32d3f742bd8"
 # The EC2 instance role to access S3
 AWS_ROLE_ARN="YOUR-AWS-ROLE-ARN"
+# The IAM instance profile for the EC2 instance to assume
+AWS_INSTANCE_PROFILE_ARN="YOUR-AWS-INSTANCE-PROFILE-ARN"
 
 ### AUTHENTICATION ###
 ### These configs are related to the authentication of users.

--- a/packages/actions/.env.default
+++ b/packages/actions/.env.default
@@ -46,8 +46,6 @@ AWS_SECRET_ACCESS_KEY="YOUR-AWS-SECRET-ACCESS-KEY"
 AWS_REGION="YOUR-AWS-REGION"
 # The AWS AMI ID (default to Amazon Linux 2).
 AWS_AMI_ID="ami-022e1a32d3f742bd8"
-# The EC2 instance role to access S3
-AWS_ROLE_ARN="YOUR-AWS-ROLE-ARN"
 # The IAM instance profile for the EC2 instance to assume
 AWS_INSTANCE_PROFILE_ARN="YOUR-AWS-INSTANCE-PROFILE-ARN"
 

--- a/packages/actions/src/helpers/services.ts
+++ b/packages/actions/src/helpers/services.ts
@@ -34,6 +34,7 @@ export const getAWSVariables = (): AWSVariables => {
         !process.env.AWS_SECRET_ACCESS_KEY ||
         !process.env.AWS_REGION ||
         !process.env.AWS_ROLE_ARN ||
+        !process.env.AWS_INSTANCE_PROFILE_ARN ||
         !process.env.AWS_AMI_ID
     )
         throw new Error(
@@ -45,6 +46,7 @@ export const getAWSVariables = (): AWSVariables => {
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
         region: process.env.AWS_REGION || "us-east-1",
         roleArn: process.env.AWS_ROLE_ARN!,
+        instanceProfileArn: process.env.AWS_INSTANCE_PROFILE_ARN!,
         amiId: process.env.AWS_AMI_ID!
     }
 }

--- a/packages/actions/src/helpers/services.ts
+++ b/packages/actions/src/helpers/services.ts
@@ -33,7 +33,6 @@ export const getAWSVariables = (): AWSVariables => {
         !process.env.AWS_ACCESS_KEY_ID ||
         !process.env.AWS_SECRET_ACCESS_KEY ||
         !process.env.AWS_REGION ||
-        !process.env.AWS_ROLE_ARN ||
         !process.env.AWS_INSTANCE_PROFILE_ARN ||
         !process.env.AWS_AMI_ID
     )
@@ -45,7 +44,6 @@ export const getAWSVariables = (): AWSVariables => {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
         region: process.env.AWS_REGION || "us-east-1",
-        roleArn: process.env.AWS_ROLE_ARN!,
         instanceProfileArn: process.env.AWS_INSTANCE_PROFILE_ARN!,
         amiId: process.env.AWS_AMI_ID!
     }

--- a/packages/actions/src/helpers/vm.ts
+++ b/packages/actions/src/helpers/vm.ts
@@ -153,7 +153,7 @@ export const createEC2Instance = async (
     diskType: DiskTypeForVM
 ): Promise<EC2Instance> => {
     // Get the AWS variables.
-    const { amiId, roleArn } = getAWSVariables()
+    const { amiId, instanceProfileArn } = getAWSVariables()
 
     // Parametrize the VM EC2 instance.
     const params: RunInstancesCommandInput = {
@@ -163,7 +163,7 @@ export const createEC2Instance = async (
         MinCount: 1,
         // nb. to find this: iam -> roles -> role_name.
         IamInstanceProfile: {
-            Arn: roleArn
+            Arn: instanceProfileArn
         },
         // nb. for running commands at the startup.
         UserData: Buffer.from(commands.join("\n")).toString("base64"),

--- a/packages/actions/src/types/index.ts
+++ b/packages/actions/src/types/index.ts
@@ -25,6 +25,7 @@ export type AWSVariables = {
     secretAccessKey: string
     region: string
     roleArn: string
+    instanceProfileArn: string
     amiId: string
 }
 

--- a/packages/actions/src/types/index.ts
+++ b/packages/actions/src/types/index.ts
@@ -17,14 +17,13 @@ import {
  * @property {string} accessKeyId - the key identifier related to S3 APIs.
  * @property {string} secretAccessKey - the secret access key related to S3 APIs.
  * @property {string} region - the region where your buckets are located.
- * @property {string} roleArn - the EC2 instance role to access S3.
+ * @property {string} instanceProfileArn - the EC2 instance profile the VM should use to access S3.
  * @property {string} amiId - the AWS AMI ID (default to Amazon Linux 2).
  */
 export type AWSVariables = {
     accessKeyId: string
     secretAccessKey: string
     region: string
-    roleArn: string
     instanceProfileArn: string
     amiId: string
 }

--- a/packages/backend/.default.env
+++ b/packages/backend/.default.env
@@ -14,8 +14,6 @@ AWS_PRESIGNED_URL_EXPIRATION="900"
 AWS_CEREMONY_BUCKET_POSTFIX="-ph2-ceremony"
 # The AWS AMI ID (default to Amazon Linux 2).
 AWS_AMI_ID="ami-022e1a32d3f742bd8"
-# The EC2 instance role to access S3
-AWS_ROLE_ARN="YOUR-AWS-ROLE-ARN"
 # The IAM instance profile for the EC2 instance to assume
 AWS_INSTANCE_PROFILE_ARN="YOUR-AWS-INSTANCE-PROFILE-ARN"
 # The SNS topic ARN to publish notifications 

--- a/packages/backend/.default.env
+++ b/packages/backend/.default.env
@@ -16,6 +16,8 @@ AWS_CEREMONY_BUCKET_POSTFIX="-ph2-ceremony"
 AWS_AMI_ID="ami-022e1a32d3f742bd8"
 # The EC2 instance role to access S3
 AWS_ROLE_ARN="YOUR-AWS-ROLE-ARN"
+# The IAM instance profile for the EC2 instance to assume
+AWS_INSTANCE_PROFILE_ARN="YOUR-AWS-INSTANCE-PROFILE-ARN"
 # The SNS topic ARN to publish notifications 
 AWS_SNS_TOPIC_ARN="YOUR-AWS-SNS-TOPIC-ARN"
 

--- a/packages/backend/src/lib/utils.ts
+++ b/packages/backend/src/lib/utils.ts
@@ -404,7 +404,7 @@ export const getAWSVariables = (): any => {
     if (
         !process.env.AWS_ACCESS_KEY_ID ||
         !process.env.AWS_SECRET_ACCESS_KEY ||
-        !process.env.AWS_ROLE_ARN ||
+        !process.env.AWS_INSTANCE_PROFILE_ARN ||
         !process.env.AWS_AMI_ID ||
         !process.env.AWS_SNS_TOPIC_ARN
     )
@@ -414,7 +414,7 @@ export const getAWSVariables = (): any => {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
         region: process.env.AWS_REGION || "eu-central-1",
-        roleArn: process.env.AWS_ROLE_ARN!,
+        instanceProfileArn: process.env.AWS_INSTANCE_PROFILE_ARN!,
         amiId: process.env.AWS_AMI_ID!,
         snsTopic: process.env.AWS_SNS_TOPIC_ARN!
     }


### PR DESCRIPTION
---
name: Pull Request
about: Open a PR for p0tion
---

# Description

On our own deployed infra, when verifying a large circuit using the `VM` verification method, the EC2 instance fails to start due to `invalid instance profile arn`. This PR fixes the issue by requiring the developer to provide the instance profile ARN (one of the values emitted by the current terraform script) in `.env` and then using in `createEC2Instance`.

# Checklist:

-   [X] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
