### PR TITLE
Fix CI workflow to deploy proper dependecies to each environment

### DIFF
--- a/.github/workflows/deploy-and-test-dev.yaml
+++ b/.github/workflows/deploy-and-test-dev.yaml
@@ -13,6 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  publish-cli-package:
+    if: github.ref == 'refs/heads/dev'
+    uses: ./.github/workflows/publish-dev-packages.yaml
+
   deploy-dev:
     uses: ./.github/workflows/firebase-deploy-dev.yaml
     secrets: inherit

--- a/.github/workflows/deploy-and-test-dev.yaml
+++ b/.github/workflows/deploy-and-test-dev.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy-dev:
-    uses: ./.github/workflows/firebase-deploy.yaml
+    uses: ./.github/workflows/firebase-deploy-dev.yaml
     secrets: inherit
     with:
       environment: dev

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy-production:
-    uses: ./.github/workflows/firebase-deploy.yaml
+    uses: ./.github/workflows/firebase-deploy-production.yaml
     secrets: inherit
     with:
       environment: production

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -13,6 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  publish-cli-package:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish-production-packages.yaml
+
   deploy-production:
     uses: ./.github/workflows/firebase-deploy-production.yaml
     secrets: inherit

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -13,6 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  publish-cli-package:
+    if: github.ref == 'refs/heads/staging'
+    uses: ./.github/workflows/publish-staging-packages.yaml
+
   deploy-staging:
     uses: ./.github/workflows/firebase-deploy-staging.yaml
     secrets: inherit

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy-staging:
-    uses: ./.github/workflows/firebase-deploy.yaml
+    uses: ./.github/workflows/firebase-deploy-staging.yaml
     secrets: inherit
     with:
       environment: staging

--- a/.github/workflows/firebase-deploy-dev.yaml
+++ b/.github/workflows/firebase-deploy-dev.yaml
@@ -1,0 +1,74 @@
+name: Deploy to Firebase Dev Environment
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to deploy"
+        required: true
+        type: string
+
+      environment:
+        description: "Environment to deploy to"
+        required: true
+        type: string
+
+      firebase_project:
+        description: "The name of the Firebase project to deploy to"
+        required: true
+        type: string
+
+jobs:
+  deploy-p0tion:
+    runs-on: ubuntu-22.04
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update package.json dependencies and names
+        run: |
+          # Enable recursive globbing
+          shopt -s globstar
+
+          # Update package.json dependencies
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
+
+          # Update string literals in TypeScript files
+          sed -i 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
+
+          cat ./packages/backend/package.json
+          cat ./packages/backend/src/functions/ceremony.ts
+
+      - name: Install npm packages and write env
+        run: |
+          yarn install
+
+          echo "${{ secrets.ACTIONS_ENV_FILE }}" > ./packages/actions/.env
+          echo "${{ secrets.BACKEND_ENV_FILE }}" > ./packages/backend/.env
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+
+      - name: build packages
+        run: yarn build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+
+      # Workaround for SSL error. (resource: https://github.com/firebase/firebase-admin-node/issues/1712)
+      - name: SSL Workaround
+        run: sudo sed -i '54 s/^/#/' /usr/lib/ssl/openssl.cnf
+
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only functions --project ${{ inputs.firebase_project }}
+        env:
+          GCP_SA_KEY: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+          PROJECT_PATH: ./packages/backend

--- a/.github/workflows/firebase-deploy-production.yaml
+++ b/.github/workflows/firebase-deploy-production.yaml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase
+name: Deploy to Firebase Production Environment
 
 on:
   workflow_call:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install npm packages and write env
         run: |
-          yarn install --immutable
+          yarn install
 
           echo "${{ secrets.ACTIONS_ENV_FILE }}" > ./packages/actions/.env
           echo "${{ secrets.BACKEND_ENV_FILE }}" > ./packages/backend/.env

--- a/.github/workflows/firebase-deploy-staging.yaml
+++ b/.github/workflows/firebase-deploy-staging.yaml
@@ -1,0 +1,71 @@
+name: Deploy to Firebase Staging Environment
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to deploy"
+        required: true
+        type: string
+
+      environment:
+        description: "Environment to deploy to"
+        required: true
+        type: string
+
+      firebase_project:
+        description: "The name of the Firebase project to deploy to"
+        required: true
+        type: string
+
+jobs:
+  deploy-p0tion:
+    runs-on: ubuntu-22.04
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update package.json dependencies and names
+        run: |
+          # Enable recursive globbing
+          shopt -s globstar
+
+          # Update package.json dependencies
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
+
+          # Update string literals in TypeScript files
+          sed -i 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
+
+      - name: Install npm packages and write env
+        run: |
+          yarn install
+
+          echo "${{ secrets.ACTIONS_ENV_FILE }}" > ./packages/actions/.env
+          echo "${{ secrets.BACKEND_ENV_FILE }}" > ./packages/backend/.env
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+
+      - name: build packages
+        run: yarn build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+
+      # Workaround for SSL error. (resource: https://github.com/firebase/firebase-admin-node/issues/1712)
+      - name: SSL Workaround
+        run: sudo sed -i '54 s/^/#/' /usr/lib/ssl/openssl.cnf
+
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only functions --project ${{ inputs.firebase_project }}
+        env:
+          GCP_SA_KEY: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+          PROJECT_PATH: ./packages/backend

--- a/.github/workflows/publish-dev-packages.yaml
+++ b/.github/workflows/publish-dev-packages.yaml
@@ -1,9 +1,7 @@
 name: Publish @devtion
 
 on:
-  push:
-    branches:
-      - dev
+  workflow_call:
 
 jobs:
   npm-publish-dev:

--- a/.github/workflows/publish-production-packages.yaml
+++ b/.github/workflows/publish-production-packages.yaml
@@ -1,9 +1,7 @@
 name: Publish @p0tion
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   npm-publish:

--- a/.github/workflows/publish-staging-packages.yaml
+++ b/.github/workflows/publish-staging-packages.yaml
@@ -1,9 +1,7 @@
 name: Publish @stagtion
 
 on:
-  push:
-    branches:
-      - staging
+  workflow_call:
 
 jobs:
   npm-publish-staging:


### PR DESCRIPTION
This PR fixes following problem:
"However the workflows for dev and staging deploy backend using the prod actions (@p0tion/actions) not the dev or staging (@stagtion/actions or @devtion/actions)"

The change will fix the CI to pull proper packages(@devtion/actions or @stagtion/actions) to each environment