### PR TITLE
fix: listen to user doc changes instead of fetching doc to check if exists

### DIFF
--- a/packages/actions/src/helpers/database.ts
+++ b/packages/actions/src/helpers/database.ts
@@ -6,6 +6,7 @@ import {
     Firestore,
     getDoc,
     getDocs,
+    onSnapshot,
     query,
     QueryConstraint,
     QueryDocumentSnapshot,
@@ -121,6 +122,26 @@ export const getDocumentById = async (
     const docRef = doc(firestoreDatabase, collection, documentId)
 
     return getDoc(docRef)
+}
+
+export const waitForUserDocumentToExist = (firestoreDatabase: Firestore, collection: string, documentId: string) => {
+    return new Promise<void>((resolve, reject) => {
+        const docRef = doc(firestoreDatabase, collection, documentId)
+
+        const unsubscribe = onSnapshot(
+            docRef,
+            (docSnapshot) => {
+                if (docSnapshot.exists()) {
+                    unsubscribe()
+                    resolve()
+                }
+            },
+            (error) => {
+                unsubscribe()
+                reject(error)
+            }
+        )
+    })
 }
 
 /**

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -23,7 +23,8 @@ export {
     getContributionsCollectionPath,
     getTimeoutsCollectionPath,
     getOpenedCeremonies,
-    getCeremonyCircuits
+    getCeremonyCircuits,
+    waitForUserDocumentToExist
 } from "./helpers/database"
 export {
     compareCeremonyArtifacts,

--- a/packages/actions/test/unit/contribute.test.ts
+++ b/packages/actions/test/unit/contribute.test.ts
@@ -911,7 +911,7 @@ describe("Contribute", () => {
                 false
             )
             expect(preamble).to.eq(
-                `Hey, I'm ${users[0].uid} and I have contributed to the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix}.\nThe following are my contribution signatures:`
+                `Hey, I'm ${users[0].uid} and I have contributed to the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix} MPC Phase2 Trusted Setup ceremony.\nThe following are my contribution signatures:`
             )
         })
         it("should return the correct preamble for the final contribution", () => {
@@ -921,7 +921,7 @@ describe("Contribute", () => {
                 true
             )
             expect(preamble).to.eq(
-                `Hey, I'm ${users[0].uid} and I have finalized the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix}.\nThe following are my contribution signatures:`
+                `Hey, I'm ${users[0].uid} and I have finalized the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix} MPC Phase2 Trusted Setup ceremony.\nThe following are my contribution signatures:`
             )
         })
     })

--- a/packages/actions/test/unit/contribute.test.ts
+++ b/packages/actions/test/unit/contribute.test.ts
@@ -911,7 +911,7 @@ describe("Contribute", () => {
                 false
             )
             expect(preamble).to.eq(
-                `Hey, I'm ${users[0].uid} and I have contributed to the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix} MPC Phase2 Trusted Setup ceremony.\nThe following are my contribution signatures:`
+                `Hey, I'm ${users[0].uid} and I have contributed to the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix}.\nThe following are my contribution signatures:`
             )
         })
         it("should return the correct preamble for the final contribution", () => {
@@ -921,7 +921,7 @@ describe("Contribute", () => {
                 true
             )
             expect(preamble).to.eq(
-                `Hey, I'm ${users[0].uid} and I have finalized the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix} MPC Phase2 Trusted Setup ceremony.\nThe following are my contribution signatures:`
+                `Hey, I'm ${users[0].uid} and I have finalized the ${fakeCeremoniesData.fakeCeremonyOpenedFixed.data.prefix}.\nThe following are my contribution signatures:`
             )
         })
     })

--- a/packages/phase2cli/src/commands/contribute.ts
+++ b/packages/phase2cli/src/commands/contribute.ts
@@ -21,7 +21,8 @@ import {
     FirebaseDocumentInfo,
     generateValidContributionsAttestation,
     commonTerms,
-    convertToDoubleDigits
+    convertToDoubleDigits,
+    waitForUserDocumentToExist
 } from "@p0tion/actions"
 import { DocumentSnapshot, DocumentData, Firestore, onSnapshot, Timestamp } from "firebase/firestore"
 import { Functions } from "firebase/functions"
@@ -947,15 +948,7 @@ const contribute = async (opt: any) => {
     const spinner = customSpinner(`Verifying your participant status...`, `clock`)
     spinner.start()
 
-    // Check that the user's document is created
-    const userDoc = await getDocumentById(firestoreDatabase, commonTerms.collections.users.name, user.uid)
-    const userData = userDoc.data()
-    if (!userData) {
-        spinner.fail(
-            `Unfortunately we could not find a user document with your information. This likely means that you did not pass the GitHub reputation checks and therefore are not elegible to contribute to any ceremony. If you believe you pass the requirements, it might be possible that your profile is private and we were not able to fetch your real statistics, in this case please consider making your profile public for the duration of the contribution. Please contact the coordinator if you believe this to be an error.`
-        )
-        process.exit(0)
-    }
+    await waitForUserDocumentToExist(firestoreDatabase, commonTerms.collections.users.name, user.uid)
 
     // Check the user's current participant readiness for contribution status (eligible, already contributed, timed out).
     const canParticipantContributeToCeremony = await checkParticipantForCeremony(firebaseFunctions, selectedCeremony.id)


### PR DESCRIPTION
---
name: Pull Request
about: Open a PR for p0tion
---

# Description
See https://discord.com/channels/943612659163602974/1166371125450768495/1167435859755278357
It looks like in case of a lag between the `auth` command and the `contribute` command, the user document may not yet exist in firebase.  
As a solution we can listen for document changes and wait for the document to `exists()`.

Fixes #220 

# How Has This Been Tested?
-   [ ] See unit test for `waitForUserDocumentToExist`

My unit test is a bit artificial so I am 100% my fix works as expected, I'd like to run additional manual e2e testing, but I am not sure how...

# Checklist:

-   [ ] My code follows the style guidelines of this project
       This PR deliberately doesn't follow style guidelines to avoid big diff, I suggest merging https://github.com/privacy-scaling-explorations/p0tion/pull/225 first then rebase
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
