### PR TITLE
fix(timeout): fix wrong variable name from desconstructing ceremony data

### DIFF
--- a/packages/backend/src/functions/timeout.ts
+++ b/packages/backend/src/functions/timeout.ts
@@ -64,7 +64,7 @@ export const checkAndRemoveBlockingContributor = functions
                 const circuits = await getCeremonyCircuits(ceremony.id)
 
                 // Extract ceremony data.
-                const { timeoutMechanismType, penalty } = ceremony.data()!
+                const { timeoutType: timeoutMechanismType, penalty } = ceremony.data()!
 
                 for (const circuit of circuits) {
                     if (!circuit.data())


### PR DESCRIPTION
we are deconstructing a variable from the ceremony data object using the wrong name -> resulting in an undefined value
fix #228 