### PR TITLE
fix: r1cs iteration exit once section 1 read

### DIFF
--- a/packages/actions/src/helpers/utils.ts
+++ b/packages/actions/src/helpers/utils.ts
@@ -424,9 +424,10 @@ export const getR1CSInfo = (localR1CSFilePath: string): CircuitMetadata => {
 
         // Jump to first section.
         pointer = 12
+        let found = false
 
         // For each section
-        for (let i = 0; i < numberOfSections; i++) {
+        for (let i = 0; i < numberOfSections && !found; i++) {
             // Read section type.
             const sectionType = ffUtils.leBuff2int(readBytesFromFile(localR1CSFilePath, 0, 4, pointer))
 
@@ -485,6 +486,8 @@ export const getR1CSInfo = (localR1CSFilePath: string): CircuitMetadata => {
                 pointer += 8
 
                 constraints = Number(ffUtils.leBuff2int(readBytesFromFile(localR1CSFilePath, 0, 4, pointer)))
+
+                found = true
             }
 
             pointer += 8 + Number(sectionSize)


### PR DESCRIPTION
---
name: Pull Request
about: Open a PR for p0tion
---

# Description

The logic only requires section 1 of the r1cs to be read. The pointer increments incorrectly if it is allowed to iterate beyond section 1, causing errors. 

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

-   [ x] Test with r1cs file that was previously failing

# Checklist:

-   [x ] My code follows the style guidelines of this project
-   [ x] I have performed a self-review of my own code
-   [ x] I have commented my code, particularly in hard-to-understand areas
-   [ x] I have made corresponding changes to the documentation
-   [ x] My changes generate no new warnings
-   [ x] Any dependent changes have been merged and published in downstream modules
-   [ x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
