### PR TITLE
workflow(fix): silent sed errors

### DIFF
--- a/.github/workflows/firebase-deploy-dev.yaml
+++ b/.github/workflows/firebase-deploy-dev.yaml
@@ -39,10 +39,10 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
 
           # Update string literals in TypeScript files
-          sed -i 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
+          sed -i -s 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
 
           cat ./packages/backend/package.json
           cat ./packages/backend/src/functions/ceremony.ts

--- a/.github/workflows/firebase-deploy-dev.yaml
+++ b/.github/workflows/firebase-deploy-dev.yaml
@@ -39,10 +39,10 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
 
           # Update string literals in TypeScript files
-          sed -i -s 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
+          find packages -type f -name '*.ts' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|devtion/actions|g' {} +
 
           cat ./packages/backend/package.json
           cat ./packages/backend/src/functions/ceremony.ts

--- a/.github/workflows/firebase-deploy-staging.yaml
+++ b/.github/workflows/firebase-deploy-staging.yaml
@@ -42,7 +42,7 @@ jobs:
           sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
 
           # Update string literals in TypeScript files
-          find packages -type f -name '*.ts' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|devtion/actions|g' {} +
+          find packages -type f -name '*.ts' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|stagtion/actions|g' {} +
 
       - name: Install npm packages and write env
         run: |

--- a/.github/workflows/firebase-deploy-staging.yaml
+++ b/.github/workflows/firebase-deploy-staging.yaml
@@ -39,10 +39,10 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
 
           # Update string literals in TypeScript files
-          sed -i 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
+          sed -i -s 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
 
       - name: Install npm packages and write env
         run: |

--- a/.github/workflows/firebase-deploy-staging.yaml
+++ b/.github/workflows/firebase-deploy-staging.yaml
@@ -39,10 +39,10 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
 
           # Update string literals in TypeScript files
-          sed -i -s 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
+          find packages -type f -name '*.ts' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|devtion/actions|g' {} +
 
       - name: Install npm packages and write env
         run: |

--- a/.github/workflows/publish-dev-packages.yaml
+++ b/.github/workflows/publish-dev-packages.yaml
@@ -34,17 +34,17 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
-          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/phase2cli/package.json
+          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/phase2cli/package.json
 
           # Update package names
-          sed -i -e 's/"name": "@p0tion\/phase2cli"/"name": "@devtion\/devcli"/g' ./packages/phase2cli/package.json
-          sed -i -e 's/"name": "@p0tion\/backend"/"name": "@devtion\/backend"/g' ./packages/backend/package.json
-          sed -i -e 's/"name": "@p0tion\/actions"/"name": "@devtion\/actions"/g' ./packages/actions/package.json
+          sed -i -e -s 's/"name": "@p0tion\/phase2cli"/"name": "@devtion\/devcli"/g' ./packages/phase2cli/package.json
+          sed -i -e -s 's/"name": "@p0tion\/backend"/"name": "@devtion\/backend"/g' ./packages/backend/package.json
+          sed -i -e -s 's/"name": "@p0tion\/actions"/"name": "@devtion\/actions"/g' ./packages/actions/package.json
 
           # Update string literals in TypeScript and JS files
-          sed -i 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
-          sed -i 's|p0tion/actions|devtion/actions|g' packages/**/*.js
+          sed -i -s 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
+          sed -i -s 's|p0tion/actions|devtion/actions|g' packages/**/*.js
 
       - name: Install lerna
         run: |

--- a/.github/workflows/publish-dev-packages.yaml
+++ b/.github/workflows/publish-dev-packages.yaml
@@ -34,17 +34,17 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
-          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/phase2cli/package.json
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@devtion\/actions": "latest"/g' ./packages/phase2cli/package.json
 
           # Update package names
-          sed -i -e -s 's/"name": "@p0tion\/phase2cli"/"name": "@devtion\/devcli"/g' ./packages/phase2cli/package.json
-          sed -i -e -s 's/"name": "@p0tion\/backend"/"name": "@devtion\/backend"/g' ./packages/backend/package.json
-          sed -i -e -s 's/"name": "@p0tion\/actions"/"name": "@devtion\/actions"/g' ./packages/actions/package.json
+          sed -i -e 's/"name": "@p0tion\/phase2cli"/"name": "@devtion\/devcli"/g' ./packages/phase2cli/package.json
+          sed -i -e 's/"name": "@p0tion\/backend"/"name": "@devtion\/backend"/g' ./packages/backend/package.json
+          sed -i -e 's/"name": "@p0tion\/actions"/"name": "@devtion\/actions"/g' ./packages/actions/package.json
 
           # Update string literals in TypeScript and JS files
-          sed -i -s 's|p0tion/actions|devtion/actions|g' packages/**/*.ts
-          sed -i -s 's|p0tion/actions|devtion/actions|g' packages/**/*.js
+          find packages -type f -name '*.ts' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|devtion/actions|g' {} +
+          find packages -type f -name '*.js' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|devtion/actions|g' {} +
 
       - name: Install lerna
         run: |

--- a/.github/workflows/publish-staging-packages.yaml
+++ b/.github/workflows/publish-staging-packages.yaml
@@ -34,17 +34,17 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
-          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/phase2cli/package.json
+          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/phase2cli/package.json
 
           # Update package names
-          sed -i -e 's/"name": "@p0tion\/phase2cli"/"name": "@stagtion\/stagcli"/g' ./packages/phase2cli/package.json
-          sed -i -e 's/"name": "@p0tion\/backend"/"name": "@stagtion\/backend"/g' ./packages/backend/package.json
-          sed -i -e 's/"name": "@p0tion\/actions"/"name": "@stagtion\/actions"/g' ./packages/actions/package.json
+          sed -i -e -s 's/"name": "@p0tion\/phase2cli"/"name": "@stagtion\/stagcli"/g' ./packages/phase2cli/package.json
+          sed -i -e -s 's/"name": "@p0tion\/backend"/"name": "@stagtion\/backend"/g' ./packages/backend/package.json
+          sed -i -e -s 's/"name": "@p0tion\/actions"/"name": "@stagtion\/actions"/g' ./packages/actions/package.json
 
           # Update string literals in TypeScript and JS files
-          sed -i 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
-          sed -i 's|p0tion/actions|stagtion/actions|g' packages/**/*.js
+          sed -i -s 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
+          sed -i -s 's|p0tion/actions|stagtion/actions|g' packages/**/*.js
 
       - name: Install lerna
         run: |

--- a/.github/workflows/publish-staging-packages.yaml
+++ b/.github/workflows/publish-staging-packages.yaml
@@ -34,17 +34,17 @@ jobs:
           shopt -s globstar
 
           # Update package.json dependencies
-          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
-          sed -i -e -s 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/phase2cli/package.json
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/backend/package.json
+          sed -i -e 's/"@p0tion\/actions": "[^"]*"/"@stagtion\/actions": "latest"/g' ./packages/phase2cli/package.json
 
           # Update package names
-          sed -i -e -s 's/"name": "@p0tion\/phase2cli"/"name": "@stagtion\/stagcli"/g' ./packages/phase2cli/package.json
-          sed -i -e -s 's/"name": "@p0tion\/backend"/"name": "@stagtion\/backend"/g' ./packages/backend/package.json
-          sed -i -e -s 's/"name": "@p0tion\/actions"/"name": "@stagtion\/actions"/g' ./packages/actions/package.json
+          sed -i -e 's/"name": "@p0tion\/phase2cli"/"name": "@stagtion\/stagcli"/g' ./packages/phase2cli/package.json
+          sed -i -e 's/"name": "@p0tion\/backend"/"name": "@stagtion\/backend"/g' ./packages/backend/package.json
+          sed -i -e 's/"name": "@p0tion\/actions"/"name": "@stagtion\/actions"/g' ./packages/actions/package.json
 
           # Update string literals in TypeScript and JS files
-          sed -i -s 's|p0tion/actions|stagtion/actions|g' packages/**/*.ts
-          sed -i -s 's|p0tion/actions|stagtion/actions|g' packages/**/*.js
+          find packages -type f -name '*.ts' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|stagtion/actions|g' {} +
+          find packages -type f -name '*.js' ! -path '*/node_modules/*' -exec sed -i 's|p0tion/actions|stagtion/actions|g' {} +
 
       - name: Install lerna
         run: |


### PR DESCRIPTION
Fixes # (issue)

prevent the command `sed` from throwing error if a file is un-editable (usually there are some files which are not normal .ts files that the program wont be able to open).