### PR TITLE
Increasing memory limit to 2gb in upload functions

### DIFF
--- a/packages/backend/src/functions/storage.ts
+++ b/packages/backend/src/functions/storage.ts
@@ -341,7 +341,7 @@ export const generateGetObjectPreSignedUrl = functions
 export const startMultiPartUpload = functions
     .region("europe-west1")
     .runWith({
-        memory: "512MB"
+        memory: "1GB"
     })
     .https.onCall(async (data: StartMultiPartUploadData, context: functions.https.CallableContext): Promise<any> => {
         if (!context.auth || (!context.auth.token.participant && !context.auth.token.coordinator))

--- a/packages/backend/src/functions/storage.ts
+++ b/packages/backend/src/functions/storage.ts
@@ -341,7 +341,7 @@ export const generateGetObjectPreSignedUrl = functions
 export const startMultiPartUpload = functions
     .region("europe-west1")
     .runWith({
-        memory: "1GB"
+        memory: "2GB"
     })
     .https.onCall(async (data: StartMultiPartUploadData, context: functions.https.CallableContext): Promise<any> => {
         if (!context.auth || (!context.auth.token.participant && !context.auth.token.coordinator))
@@ -487,7 +487,7 @@ export const generatePreSignedUrlsParts = functions
 export const completeMultiPartUpload = functions
     .region("europe-west1")
     .runWith({
-        memory: "512MB"
+        memory: "2GB"
     })
     .https.onCall(async (data: CompleteMultiPartUploadData, context: functions.https.CallableContext): Promise<any> => {
         if (!context.auth || (!context.auth.token.participant && !context.auth.token.coordinator))


### PR DESCRIPTION
---
name: Increasing memory limit to 2gb in upload functions
---

# Description

I am increasing the memory limit to 2gb to test if we reduce the `function/unavailable` errors in the middle of the contribution step from the CLI. It looks like that for large circuits we need more memory to compute in the cloud function.
