### PR TITLE
Fix the issue that 'Firebase Function' might can't deploy

### DIFF
--- a/packages/backend/firebase.json
+++ b/packages/backend/firebase.json
@@ -5,7 +5,11 @@
     },
     "functions": {
         "predeploy": "yarn --cwd \"$RESOURCE_DIR\" build",
-        "source": "."
+        "source": ".",
+        "ignore": [
+            "node_modules",
+            "aws"
+        ]
     },
     "emulators": {
         "singleProjectMode": true,


### PR DESCRIPTION
name: Pull Request
about: Open a PR for p0tion
---

# Description

Might encounter an error when running the following commands:

```shell
cd packages/backend
yarn firebase:deploy
```

Error message:

```
⚠  functions: Upload Error: HTTP Error: 400, <?xml version='1.0' encoding='UTF-8'?><Error><Code>EntityTooLarge</Code><Message>Your proposed upload is larger than the maximum object size specified in your Policy Document.</Message><Details>Content-length exceeds upper bound on range</Details></Error>
```

Error Details: The uploaded Firebase function source code package is too large (exceeds 100MB).

Cause: After running `terraform` in the `backend/aws` folder, temporary files larger than 500MB are generated in `backend/aws`. The `backend/aws` folder is not needed for deploying Firebase functions.

**Solution**:

Modify the `firebase.json` file to exclude the `backend/aws` folder:

Before:

```json
    "functions": {
        "predeploy": "yarn --cwd \"$RESOURCE_DIR\" build",
        "source": "."
    }
```

After modification:

```json
    "functions": {
        "predeploy": "yarn --cwd \"$RESOURCE_DIR\" build",
        "source": ".",
        "ignore": [
            "node_modules",
            "aws"
        ]
    }
```

- Note:

  - Why add `node_modules`?

    In the [firebase-tools source code](https://github.com/firebase/firebase-tools/blob/v13.12.0/src/deploy/functions/prepareFunctionsUpload.ts#L75):

    ```typescript const ignore = config.ignore || ["node_modules", ".git"]; ```

    When the `ignore` node is not configured, `node_modules` is automatically ignored. However, when `ignore` is manually added, you must also manually add `node_modules` to the `ignore` list.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

-   [ ] Test A
-   [ ] Test B

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
