### PR TITLE
Fixed an Issue Where `matchContributionHash` Might Not Compatible on Windows Systems

### DIFF
--- a/packages/actions/test/e2e/contribution.test.ts
+++ b/packages/actions/test/e2e/contribution.test.ts
@@ -198,7 +198,7 @@ describe("Contribution", () => {
 
             // read the contribution hash
             const transcriptContents = fs.readFileSync(transcriptLocalFilePath, "utf-8").toString()
-            const matchContributionHash = transcriptContents.match(/Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+\n/)
+            const matchContributionHash = transcriptContents.match(/Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+(\r?\n)/)
             const contributionHash = matchContributionHash?.at(0)?.replace("\n\t\t", "")!
 
             await progressToNextContributionStep(userFunctions, ceremonyId)

--- a/packages/actions/test/unit/ec2.test.ts
+++ b/packages/actions/test/unit/ec2.test.ts
@@ -454,7 +454,7 @@ describe("VMs", () => {
                 // read the contribution hash
                 const transcriptContents = fs.readFileSync(transcriptLocalFilePath, "utf-8").toString()
                 const matchContributionHash = transcriptContents.match(
-                    /Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+\n/
+                    /Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+(\r?\n)/
                 )
                 const contributionHash = matchContributionHash?.at(0)?.replace("\n\t\t", "")!
 

--- a/packages/phase2cli/src/lib/utils.ts
+++ b/packages/phase2cli/src/lib/utils.ts
@@ -664,7 +664,7 @@ export const handleStartOrResumeContribution = async (
 
         // Read local transcript file info to get the contribution hash.
         const transcriptContents = readFile(transcriptLocalFilePath)
-        const matchContributionHash = transcriptContents.match(/Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+\n/)
+        const matchContributionHash = transcriptContents.match(/Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+(\r?\n)/)
 
         if (!matchContributionHash)
             showError(COMMAND_ERRORS.COMMAND_CONTRIBUTE_FINALIZE_NO_TRANSCRIPT_CONTRIBUTION_HASH_MATCH, true)


### PR DESCRIPTION
---
name: Pull Request
about: Open a PR for p0tion
---


- **Description:**

  - **Test Environment:** AWS - Windows_Server-2022-English-Full-Base-2024.06.13

  - **Steps to Reproduce:**

    1. Run:
       ```powershell
       phase2cli contribute
       ```

    2. Output:
       ```powershell
       - Circuit # 1/1 (Contribution Steps)
       √ Contribution #00000 correctly downloaded
       - Writing contribution metadata...× Unable to retrieve contribution hash from transcript. Possible causes may involve an error while using the logger or unexpected file descriptor termination. Please, terminate the current session and repeat the process.
       ```

- **Cause:**

  - **Source Code:** https://github.com/privacy-scaling-explorations/p0tion/blob/d61f85c5860b8f10e54a3ff653d0abb9b533bef4/packages/phase2cli/src/lib/utils.ts#L667

  - The issue arises because the regular expression `/Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+\n/` used to match the Contribution Hash does not compatible for differences in the "winston" logging component across platforms.

    - **Examples of Differences:**

      1. **Unix/Linux Log:**
         ```
         Circuit Hash: 
         		49119684 1980a690 2f1f8414 765927d4
         		a2c8aa83 09f7d9eb 5890d9a9 045d7bb2
         		5fa4588f 04cc9161 297c00d2 231e4f1d
         		51aa256c 3cb02c06 18c2aacc 562e515c      <---  \n
         Contribution transcript for xxxxxxx phase 2 contribution.
         ```

      2. **Windows Log:**
         ```
         Circuit Hash: 
         		49119684 1980a690 2f1f8414 765927d4
         		a2c8aa83 09f7d9eb 5890d9a9 045d7bb2
         		5fa4588f 04cc9161 297c00d2 231e4f1d
         		51aa256c 3cb02c06 18c2aacc 562e515c      <---  \r\n
         Contribution transcript for xxxxxxx phase 2 contribution.
         ```

- **Solution:**

  - To ensure compatibility with Windows systems, modify the regular expression to allow an optional `\r` before the final `\n`.

  - The updated regular expression is:

    ```regex
    /Contribution.+Hash.+\n\t\t.+\n\t\t.+\n.+\n\t\t.+(\r?\n)/
    ```


Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

-   [ ] Test A
-   [ ] Test B

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
