### PR TITLE
fix tweet url when ceremony name includes spaces

### DIFF
--- a/packages/phase2cli/src/lib/utils.ts
+++ b/packages/phase2cli/src/lib/utils.ts
@@ -312,8 +312,9 @@ export const generateCustomUrlToTweetAboutParticipation = (
     ceremonyName: string,
     gistUrl: string,
     isFinalizing: boolean
-) =>
-    isFinalizing
+) => {
+    ceremonyName = ceremonyName.replace(/ /g, "%20")
+    return isFinalizing
         ? `https://twitter.com/intent/tweet?text=I%20have%20finalized%20the%20${ceremonyName}${
               ceremonyName.toLowerCase().includes("trusted") ||
               ceremonyName.toLowerCase().includes("setup") ||
@@ -330,6 +331,7 @@ export const generateCustomUrlToTweetAboutParticipation = (
                   ? "!"
                   : "%20Phase%202%20Trusted%20Setup%20ceremony!"
           }%20You%20can%20view%20the%20steps%20to%20contribute%20here:%20https://ceremony.pse.dev%20You%20can%20view%20my%20attestation%20here:%20${gistUrl}%20#Ethereum%20#ZKP`
+}
 
 /**
  * Return a custom progress bar.


### PR DESCRIPTION
---
name: fix tweet url when ceremony name includes spaces
about: fixing twitter link
---

# Description

I replace the spaces with "%20" in the twitter link

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
