### PR TITLE
fix: do not timeout when completed

### DIFF
--- a/packages/backend/src/functions/timeout.ts
+++ b/packages/backend/src/functions/timeout.ts
@@ -144,8 +144,7 @@ export const checkAndRemoveBlockingContributor = functions
                                     timeoutExpirationDateInMsForBlockingContributor < currentServerTimestamp &&
                                     (contributionStep === ParticipantContributionStep.DOWNLOADING ||
                                         contributionStep === ParticipantContributionStep.COMPUTING ||
-                                        contributionStep === ParticipantContributionStep.UPLOADING ||
-                                        contributionStep === ParticipantContributionStep.COMPLETED)
+                                        contributionStep === ParticipantContributionStep.UPLOADING)
                                 )
                                     timeoutType = TimeoutType.BLOCKING_CONTRIBUTION
 


### PR DESCRIPTION
Do not timeout users when they have already contributed