### PR TITLE
fix: adjusts conditions to rigger coordinate function

### DIFF
--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -115,7 +115,7 @@ const coordinate = async (
     if (isSingleParticipantCoordination) {
         // Scenario (A).
         if (emptyWaitingQueue) {
-            printLog(`Coordinate - executing scenario A - emptyWaitingQueue`, LogLevel.DEBUG)
+            printLog(`Coordinate - executing scenario A - emptyWaitingQueue`, LogLevel.INFO)
 
             // Update.
             newCurrentContributorId = participant.id
@@ -127,7 +127,7 @@ const coordinate = async (
         else if (participantResumingAfterTimeoutExpiration) {
             printLog(
                 `Coordinate - executing scenario A - single - participantResumingAfterTimeoutExpiration`,
-                LogLevel.DEBUG
+                LogLevel.INFO
             )
 
             newParticipantStatus = ParticipantStatus.CONTRIBUTING
@@ -136,7 +136,7 @@ const coordinate = async (
         }
         // Scenario (B).
         else if (participantIsNotCurrentContributor) {
-            printLog(`Coordinate - executing scenario B - single - participantIsNotCurrentContributor`, LogLevel.DEBUG)
+            printLog(`Coordinate - executing scenario B - single - participantIsNotCurrentContributor`, LogLevel.INFO)
 
             newCurrentContributorId = currentContributor
             newParticipantStatus = ParticipantStatus.WAITING
@@ -160,7 +160,7 @@ const coordinate = async (
     } else if (participantIsCurrentContributor && participantCompletedOneOrAllContributions && !!ceremonyId) {
         printLog(
             `Coordinate - executing scenario C - multi - participantIsCurrentContributor && participantCompletedOneOrAllContributions`,
-            LogLevel.DEBUG
+            LogLevel.INFO
         )
 
         newParticipantStatus = ParticipantStatus.CONTRIBUTING
@@ -190,7 +190,7 @@ const coordinate = async (
 
             printLog(
                 `Participant ${newCurrentContributorId} is the new current contributor for circuit ${circuit.id}`,
-                LogLevel.DEBUG
+                LogLevel.INFO
             )
         }
     }
@@ -346,10 +346,10 @@ export const coordinateCeremonyParticipant = functionsV1
             contributionStep: changedContributionStep
         } = changedParticipant.data()!
 
-        printLog(`Coordinate participant ${exParticipant.id} for ceremony ${ceremonyId}`, LogLevel.DEBUG)
+        printLog(`Coordinate participant ${exParticipant.id} for ceremony ${ceremonyId}`, LogLevel.INFO)
         printLog(
             `Participant status: ${prevStatus} => ${changedStatus} - Participant contribution step: ${prevContributionStep} => ${changedContributionStep}`,
-            LogLevel.DEBUG
+            LogLevel.INFO
         )
 
         // Define pre-conditions.
@@ -370,8 +370,8 @@ export const coordinateCeremonyParticipant = functionsV1
 
         const participantCompletedContribution =
             prevContributionProgress === changedContributionProgress &&
-            prevStatus === ParticipantStatus.CONTRIBUTING &&
-            prevContributionStep === ParticipantContributionStep.VERIFYING &&
+            (prevStatus === ParticipantStatus.CONTRIBUTING ||
+            prevContributionStep === ParticipantContributionStep.VERIFYING) &&
             changedStatus === ParticipantStatus.CONTRIBUTED &&
             changedContributionStep === ParticipantContributionStep.COMPLETED
 
@@ -384,7 +384,7 @@ export const coordinateCeremonyParticipant = functionsV1
             // Step (2.A).
             printLog(
                 `Participant is ready for first contribution (${participantReadyForFirstContribution}) or for the next contribution (${participantReadyForNextContribution}) or is resuming after a timeout expiration (${participantResumingContributionAfterTimeout})`,
-                LogLevel.DEBUG
+                LogLevel.INFO
             )
 
             // Get the circuit.
@@ -398,7 +398,7 @@ export const coordinateCeremonyParticipant = functionsV1
             // Step (2.B).
             printLog(
                 `Participant completed a contribution (${participantCompletedContribution}) or every contribution for each circuit (${participantCompletedEveryCircuitContribution})`,
-                LogLevel.DEBUG
+                LogLevel.INFO
             )
 
             // Get the circuit.
@@ -769,7 +769,7 @@ export const verifycontribution = functionsV2.https.onCall(
                     } of circuit ${circuitId} (ceremony ${ceremonyId}) has been verified as ${
                         isContributionValid ? "valid" : "invalid"
                     } for the participant ${participantDoc.id}`,
-                    LogLevel.DEBUG
+                    LogLevel.INFO
                 )
             }
 
@@ -817,7 +817,7 @@ export const verifycontribution = functionsV2.https.onCall(
                         })
                         .catch((error: any) => {
                             // Command execution aborted.
-                            printLog(`Command ${commandId} execution has been aborted - Error ${error}`, LogLevel.DEBUG)
+                            printLog(`Command ${commandId} execution has been aborted - Error ${error}`, LogLevel.WARN)
 
                             logAndThrowError(COMMON_ERRORS.CM_INVALID_COMMAND_EXECUTION)
                         })
@@ -957,8 +957,8 @@ export const refreshParticipantAfterContributionVerification = functionsV1
         await batch.commit()
 
         printLog(
-            `Participant ${participantId} refreshed after contribution ${createdContribution.id} - The participant was finalizing the ceremony ${isFinalizing}`,
-            LogLevel.DEBUG
+            `Participant ${participantId} refreshed after contribution ${createdContribution.id} - The participant was finalizing the ceremony? ${isFinalizing}`,
+            LogLevel.INFO
         )
     })
 


### PR DESCRIPTION
---
name: Avoid status change that halts ceremony. see #319 #323 
about: Open a PR for p0tion
---

# Description
In rare circumstances, a contribution updates its status such that the move from one circuit to the next is not triggered. The effect is that the circuit queue freezes until manually cleared.


Fixes # (issue)
The conditions that are tested to trigger the `coordinateCeremonyParticiapnt` command were adjusted so that any change from a non-complete status/step to completed will trigger the coordinate function and clean up the circuit correctly. 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

-   [ ] Test A
-   [ ] Test B

# Checklist:

-   [x ] My code follows the style guidelines of this project
-   [x ] I have performed a self-review of my own code
-   [ x] I have commented my code, particularly in hard-to-understand areas
-   [ x] I have made corresponding changes to the documentation
-   [ x] My changes generate no new warnings
-   [ x] Any dependent changes have been merged and published in downstream modules
-   [ x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
