### PR TITLE
fix: increase memory limit for verify contribution cf

### DIFF
--- a/packages/backend/src/functions/bandada.ts
+++ b/packages/backend/src/functions/bandada.ts
@@ -15,7 +15,7 @@ const bandadaApi = new ApiSdk(BANDADA_API_URL)
 export const bandadaValidateProof = functions
     .region("europe-west1")
     .runWith({
-        memory: "512MB"
+        memory: "1GB"
     })
     .https.onCall(async (data: BandadaValidateProof): Promise<VerifiedBandadaResponse> => {
         const VKEY_DATA = {

--- a/packages/backend/src/functions/ceremony.ts
+++ b/packages/backend/src/functions/ceremony.ts
@@ -232,7 +232,7 @@ export const setupCeremony = functions
 export const initEmptyWaitingQueueForCircuit = functions
     .region("europe-west1")
     .runWith({
-        memory: "512MB"
+        memory: "1GB"
     })
     .firestore.document(
         `/${commonTerms.collections.ceremonies.name}/{ceremony}/${commonTerms.collections.circuits.name}/{circuit}`

--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -460,7 +460,7 @@ const checkIfVMRunning = async (ec2: EC2Client, vmInstanceId: string, attempts =
  * 2) Send all updates atomically to the Firestore database.
  */
 export const verifycontribution = functionsV2.https.onCall(
-    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1" },
+    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: "6" },
     async (request: functionsV2.https.CallableRequest<VerifyContributionData>): Promise<any> => {
         try {
             if (!request.auth || (!request.auth.token.participant && !request.auth.token.coordinator))

--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -460,7 +460,7 @@ const checkIfVMRunning = async (ec2: EC2Client, vmInstanceId: string, attempts =
  * 2) Send all updates atomically to the Firestore database.
  */
 export const verifycontribution = functionsV2.https.onCall(
-    { memory: "16GiB", timeoutSeconds: 3600, region: "europe-west1" },
+    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1" },
     async (request: functionsV2.https.CallableRequest<VerifyContributionData>): Promise<any> => {
         try {
             if (!request.auth || (!request.auth.token.participant && !request.auth.token.coordinator))
@@ -895,7 +895,7 @@ export const verifycontribution = functionsV2.https.onCall(
             }
         } catch (error: any) {
             logAndThrowError(makeError("unknown", error))
-        }    
+        }
     }
 )
 

--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -460,7 +460,7 @@ const checkIfVMRunning = async (ec2: EC2Client, vmInstanceId: string, attempts =
  * 2) Send all updates atomically to the Firestore database.
  */
 export const verifycontribution = functionsV2.https.onCall(
-    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: "6" },
+    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: 6 },
     async (request: functionsV2.https.CallableRequest<VerifyContributionData>): Promise<any> => {
         try {
             if (!request.auth || (!request.auth.token.participant && !request.auth.token.coordinator))

--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -460,7 +460,7 @@ const checkIfVMRunning = async (ec2: EC2Client, vmInstanceId: string, attempts =
  * 2) Send all updates atomically to the Firestore database.
  */
 export const verifycontribution = functionsV2.https.onCall(
-    { memory: "24GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: 6 },
+    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: 8 },
     async (request: functionsV2.https.CallableRequest<VerifyContributionData>): Promise<any> => {
         try {
             if (!request.auth || (!request.auth.token.participant && !request.auth.token.coordinator))

--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -460,7 +460,7 @@ const checkIfVMRunning = async (ec2: EC2Client, vmInstanceId: string, attempts =
  * 2) Send all updates atomically to the Firestore database.
  */
 export const verifycontribution = functionsV2.https.onCall(
-    { memory: "32GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: 6 },
+    { memory: "24GiB", timeoutSeconds: 3600, region: "europe-west1", cpu: 6 },
     async (request: functionsV2.https.CallableRequest<VerifyContributionData>): Promise<any> => {
         try {
             if (!request.auth || (!request.auth.token.participant && !request.auth.token.coordinator))


### PR DESCRIPTION
---
name: increase memory limit for verify contribution cf
---

# Description
 We are getting memory limit errors when running the zk-email ceremony. I already tried to change the contribution computation to VMs rather than CFs but it is still giving errors. I decided to increase the memory limit for the verify contribution cloud function.
