### PR TITLE
Fix: Set region for prod testing

### DIFF
--- a/packages/actions/test/utils/configs.ts
+++ b/packages/actions/test/utils/configs.ts
@@ -66,8 +66,9 @@ export const initializeUserServices = (): {
     // Init services.
     const auth = getAuth(userApp)
     const userFirestore = envType === TestingEnvironment.PRODUCTION ? getFirestore(userApp) : getFirestore()
-    const userFunctions =
-        envType === TestingEnvironment.PRODUCTION ? getFunctions(userApp) : getFunctions(getApp(), "europe-west1")
+    const userFunctions = envType === TestingEnvironment.PRODUCTION
+        ? getFunctions(userApp, "europe-west1")
+        : getFunctions(getApp(), "europe-west1")
 
     if (envType === TestingEnvironment.DEVELOPMENT) {
         // Connect the emulator for dev environment (default endpoints).


### PR DESCRIPTION
`yarn test:prod` was failing with a `Firebase: not-found` error.
Setting the region for prod testing resolves it.

# How Has This Been Tested?

-   [x] Running the unittests `yarn test:prod`

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (Is there something to change?)
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
