### PR TITLE
Feat: more helpful backend logs

### DIFF
--- a/packages/backend/src/functions/participant.ts
+++ b/packages/backend/src/functions/participant.ts
@@ -215,7 +215,14 @@ export const progressToNextCircuitForContribution = functions
                 status: ParticipantStatus.READY,
                 lastUpdated: getCurrentServerTimestampInMillis()
             })
-        else logAndThrowError(SPECIFIC_ERRORS.SE_CONTRIBUTE_CANNOT_PROGRESS_TO_NEXT_CIRCUIT)
+        else {
+            printLog(
+                `Participant/Contributor ${userId} cannot progress to the next circuit. ` +
+                `contributionProgress: ${contributionProgress} - contributionStep: ${contributionStep} - status: ${status}`,
+                LogLevel.DEBUG
+            )
+            logAndThrowError(SPECIFIC_ERRORS.SE_CONTRIBUTE_CANNOT_PROGRESS_TO_NEXT_CIRCUIT)
+        }
 
         printLog(
             `Participant/Contributor ${userId} progress to the circuit in position ${contributionProgress + 1}`,

--- a/packages/backend/src/lib/utils.ts
+++ b/packages/backend/src/lib/utils.ts
@@ -31,7 +31,8 @@ import path from "path"
 import os from "os"
 import { SSMClient } from "@aws-sdk/client-ssm"
 import { EC2Client } from "@aws-sdk/client-ec2"
-import { COMMON_ERRORS, logAndThrowError, SPECIFIC_ERRORS } from "./errors"
+import { COMMON_ERRORS, logAndThrowError, SPECIFIC_ERRORS, printLog } from "./errors"
+import { LogLevel } from "../types/enums"
 import { getS3Client } from "./services"
 
 dotenv.config()
@@ -54,8 +55,12 @@ export const getDocumentById = async (
 
     // Get document.
     const doc = await firestore.collection(collection).doc(documentId).get()
+    await firestore.collection(collection).listDocuments()
 
     // Return only if doc exists; otherwise throw error.
+    if (!doc.exists) {
+        printLog(`Document ${documentId} does not exist in collection ${collection}`, LogLevel.ERROR)
+    }
     return doc.exists ? doc : logAndThrowError(COMMON_ERRORS.CM_INEXISTENT_DOCUMENT)
 }
 


### PR DESCRIPTION
# Description

While debugging issues during testing and the ceremony, it was very helpful to have additional details in the backend error logs.

# How Has This Been Tested?

-   [x] Deployment finished without errors
-   [x] Running the unittests `yarn test:prod`
-   [x] Completing the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony)

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (Is there something to change?)
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
