### PR TITLE
Fix: backend time conversion of fixed timeouts

### DIFF
--- a/packages/backend/src/functions/timeout.ts
+++ b/packages/backend/src/functions/timeout.ts
@@ -128,7 +128,7 @@ export const checkAndRemoveBlockingContributor = functions
                                         ? Number(contributionStartedAt) +
                                           Number(avgFullContribution) +
                                           Number(timeoutDynamicThreshold)
-                                        : ( Number(contributionStartedAt) + Number(fixedTimeWindow) ) * 60000 // * 60000 = convert minutes to millis.
+                                        : (Number(contributionStartedAt) + Number(fixedTimeWindow) * 60000) // * 60000 = convert minutes to millis.
 
                                 // Case (D).
                                 const timeoutExpirationDateInMsForVerificationCloudFunction =


### PR DESCRIPTION
# Description

Fixed timeouts did not work. There was a small scope mistake in the calculation of the expiration time. It converted `contributionStartedAt` from minutes to millis although `contributionStartedAt` already was in millis.

# How Has This Been Tested?

-   [x] Deployment finished without errors
-   [x] Running the unittests `yarn test:prod`
-   [x] Completing the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony)

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (Is there something to change?)
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)

