### PR TITLE
Fix: backend handling resuming contributions

### DIFF
--- a/packages/backend/src/functions/circuit.ts
+++ b/packages/backend/src/functions/circuit.ts
@@ -371,7 +371,7 @@ export const coordinateCeremonyParticipant = functionsV1
         const participantCompletedContribution =
             prevContributionProgress === changedContributionProgress &&
             (prevStatus === ParticipantStatus.CONTRIBUTING ||
-            prevContributionStep === ParticipantContributionStep.VERIFYING) &&
+                prevContributionStep === ParticipantContributionStep.VERIFYING) &&
             changedStatus === ParticipantStatus.CONTRIBUTED &&
             changedContributionStep === ParticipantContributionStep.COMPLETED
 
@@ -537,11 +537,10 @@ export const verifycontribution = functionsV2.https.onCall(
 
             // Derive necessary data.
             const lastZkeyIndex = formatZkeyIndex(completedContributions + 1)
-            const verificationTranscriptCompleteFilename = `${prefix}_${
-                isFinalizing
+            const verificationTranscriptCompleteFilename = `${prefix}_${isFinalizing
                     ? `${contributorOrCoordinatorIdentifier}_${finalContributionIndex}_verification_transcript.log`
                     : `${lastZkeyIndex}_${contributorOrCoordinatorIdentifier}_verification_transcript.log`
-            }`
+                }`
 
             const lastZkeyFilename = `${prefix}_${isFinalizing ? finalContributionIndex : lastZkeyIndex}.zkey`
 
@@ -666,11 +665,11 @@ export const verifycontribution = functionsV2.https.onCall(
                     )
 
                     /// @dev (there must be only one contribution with an empty 'doc' field).
-                    if (participantContributions.length !== 1)
+                    if (participantContributions.length === 0)
                         logAndThrowError(SPECIFIC_ERRORS.SE_VERIFICATION_NO_PARTICIPANT_CONTRIBUTION_DATA)
 
                     // Get contribution computation time.
-                    contributionComputationTime = contributions.at(0).computationTime
+                    contributionComputationTime = participantContributions.at(0).computationTime
 
                     // Step (1.A.4.A.2).
                     batch.create(contributionDoc.ref, {
@@ -777,10 +776,8 @@ export const verifycontribution = functionsV2.https.onCall(
                 await batch.commit()
 
                 printLog(
-                    `The contribution #${
-                        isFinalizing ? finalContributionIndex : lastZkeyIndex
-                    } of circuit ${circuitId} (ceremony ${ceremonyId}) has been verified as ${
-                        isContributionValid ? "valid" : "invalid"
+                    `The contribution #${isFinalizing ? finalContributionIndex : lastZkeyIndex
+                    } of circuit ${circuitId} (ceremony ${ceremonyId}) has been verified as ${isContributionValid ? "valid" : "invalid"
                     } for the participant ${participantDoc.id}`,
                     LogLevel.INFO
                 )
@@ -856,10 +853,8 @@ export const verifycontribution = functionsV2.https.onCall(
                 // Create and populate transcript.
                 const transcriptLogger = createCustomLoggerForFile(verificationTranscriptTemporaryLocalPath)
                 transcriptLogger.info(
-                    `${
-                        isFinalizing ? `Final verification` : `Verification`
-                    } transcript for ${prefix} circuit Phase 2 contribution.\n${
-                        isFinalizing ? `Coordinator ` : `Contributor # ${Number(lastZkeyIndex)}`
+                    `${isFinalizing ? `Final verification` : `Verification`
+                    } transcript for ${prefix} circuit Phase 2 contribution.\n${isFinalizing ? `Coordinator ` : `Contributor # ${Number(lastZkeyIndex)}`
                     } (${contributorOrCoordinatorIdentifier})\n`
                 )
 

--- a/packages/backend/src/functions/participant.ts
+++ b/packages/backend/src/functions/participant.ts
@@ -326,6 +326,7 @@ export const permanentlyStoreCurrentContributionTimeAndHash = functions
             // Pre-condition: computing contribution step or finalizing (only for coordinator when finalizing ceremony).
             if (
                 contributionStep === ParticipantContributionStep.COMPUTING ||
+                contributionStep === ParticipantContributionStep.UPLOADING || // also accepting during the upload step in case the contribution is interrupted and resumed, which requires recomputing
                 (isCoordinator && status === ParticipantStatus.FINALIZING)
             )
                 // Send tx.


### PR DESCRIPTION
# Description

During the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony) multiple users reported issues of not being able to contribute, even after retrying multiple times.
After some debugging, I came to the conclusion that they were unable to resume contributions because the backend did not allow uploading a new contribution.
When the user was interrupted for any reason during or after the uploading step, a retry generated new random input and therefore a new contribution that needed to be uploaded.

This PR fixes the issue by allowing another upload during the uploading step and handling the consequences during verification.

# How Has This Been Tested?

-   [x] Deployment finished without errors
-   [x] Running the unittests `yarn test:prod`
-   [x] Completing the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony)

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (Is there something to change?)
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
