### PR TITLE
Fix: recover from being stuck in the completed step

### DIFF
--- a/packages/backend/src/functions/timeout.ts
+++ b/packages/backend/src/functions/timeout.ts
@@ -144,7 +144,8 @@ export const checkAndRemoveBlockingContributor = functions
                                     timeoutExpirationDateInMsForBlockingContributor < currentServerTimestamp &&
                                     (contributionStep === ParticipantContributionStep.DOWNLOADING ||
                                         contributionStep === ParticipantContributionStep.COMPUTING ||
-                                        contributionStep === ParticipantContributionStep.UPLOADING)
+                                        contributionStep === ParticipantContributionStep.UPLOADING ||
+                                        contributionStep === ParticipantContributionStep.COMPLETED)
                                 )
                                     timeoutType = TimeoutType.BLOCKING_CONTRIBUTION
 


### PR DESCRIPTION
# Description

During the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony) we had rare cases of contributions being stuck in the COMPLETED step. It happened at least 3 times out of about 1600 total contributions.
I have not found the root cause, why the circuit did not proceed to the next participant. But I needed to resolve this because the issue blocked the circuit for everyone trying to contribute.

This PR allows the backend to detect a timeout in the completed state and then resolve it automatically.

# How Has This Been Tested?

-   [x] Deployment finished without errors
-   [x] Running the unittests `yarn test:prod`
-   [x] Completing the [Galactica Network Ceremony](https://ceremony.galactica.com/projects/Galactica%20ZK%20Ceremony)

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (Is there something to change?)
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I reviewed the [code of conduct](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CODE_OF_CONDUCT.md) and [contributors' guide](https://github.com/privacy-scaling-explorations/p0tion/blob/main/CONTRIBUTING.md)
